### PR TITLE
Require swapping destination to be a non-zero address

### DIFF
--- a/src/strategies/strategy-base.sol
+++ b/src/strategies/strategy-base.sol
@@ -216,6 +216,8 @@ abstract contract StrategyBase {
         address _to,
         uint256 _amount
     ) internal {
+        require(_to != address(0));
+
         // Swap with uniswap
         IERC20(_from).safeApprove(univ2Router2, 0);
         IERC20(_from).safeApprove(univ2Router2, _amount);


### PR DESCRIPTION
Fix the potential for the swapping function to be called to a zero address (potentially burning funds).