### PR TITLE
Fix redundant memory allocation for asset index type

### DIFF
--- a/src/strategies/curve/strategy-curve-scrv-v4_1.sol
+++ b/src/strategies/curve/strategy-curve-scrv-v4_1.sol
@@ -78,7 +78,7 @@ contract StrategyCurveSCRVv4_1 is StrategyBase {
         return ICurveGauge(gauge).claimable_tokens(crvLocker);
     }
 
-    function getMostPremium() public view returns (address, uint256) {
+    function getMostPremium() public view returns (address, uint8) {
         uint256[] memory balances = new uint256[](4);
         balances[0] = ICurveFi_4(curve).balances(0); // DAI
         balances[1] = ICurveFi_4(curve).balances(1).mul(10**12); // USDC


### PR DESCRIPTION
Changed from `uint256` to `uint8` as the former is unnecessarily large.