### PR TITLE
Add null address check in constructor

### DIFF
--- a/src/pickle-jar.sol
+++ b/src/pickle-jar.sol
@@ -28,6 +28,11 @@ contract PickleJar is ERC20 {
             string(abi.encodePacked("p", ERC20(_token).symbol()))
         )
     {
+        require(_token != address(0));
+        require(_governance != address(0));
+        require(_timelock != address(0));
+        require(_controller != address(0));
+
         _setupDecimals(ERC20(_token).decimals());
         token = IERC20(_token);
         governance = _governance;

--- a/src/strategies/curve/crv-locker.sol
+++ b/src/strategies/curve/crv-locker.sol
@@ -22,6 +22,7 @@ contract CRVLocker {
     mapping(address => bool) public voters;
 
     constructor(address _governance) public {
+        require(_governance != address(0));
         governance = _governance;
     }
 

--- a/src/strategies/curve/scrv-voter.sol
+++ b/src/strategies/curve/scrv-voter.sol
@@ -28,6 +28,8 @@ contract SCRVVoter {
     address public governance;
 
     constructor(address _governance, address _crvLocker) public {
+        require(_governance != address(0));
+        require(_crvLocker != address(0));
         governance = _governance;
         crvLocker = CRVLocker(_crvLocker);
     }

--- a/src/strategies/curve/strategy-curve-scrv-v4_1.sol
+++ b/src/strategies/curve/strategy-curve-scrv-v4_1.sol
@@ -60,6 +60,8 @@ contract StrategyCurveSCRVv4_1 is StrategyBase {
         curve = susdv2_pool;
         gauge = susdv2_gauge;
 
+        require(_scrvVoter != address(0));
+        require(_crvLocker != address(0));
         scrvVoter = _scrvVoter;
         crvLocker = _crvLocker;
     }

--- a/src/strategies/strategy-curve-base.sol
+++ b/src/strategies/strategy-curve-base.sol
@@ -42,6 +42,8 @@ abstract contract StrategyCurveBase is StrategyBase {
         public
         StrategyBase(_want, _governance, _strategist, _controller, _timelock)
     {
+        require(_curve != address(0));
+        require(_gauge != address(0));
         curve = _curve;
         gauge = _gauge;
     }

--- a/src/strategies/strategy-staking-rewards-base.sol
+++ b/src/strategies/strategy-staking-rewards-base.sol
@@ -19,6 +19,7 @@ abstract contract StrategyStakingRewardsBase is StrategyBase {
         public
         StrategyBase(_want, _governance, _strategist, _controller, _timelock)
     {
+        require(_rewards != address(0));
         rewards = _rewards;
     }
 

--- a/src/strategies/strategy-uni-farm-base.sol
+++ b/src/strategies/strategy-uni-farm-base.sol
@@ -33,6 +33,7 @@ abstract contract StrategyUniFarmBase is StrategyStakingRewardsBase {
             _timelock
         )
     {
+        require(_token1 != address(0));
         token1 = _token1;
     }
 


### PR DESCRIPTION
Pursuant to the **Warning 2** in MixBytes strategy contracts audit report:

**2. No check of parameter values when executing smart contract constructor**

Note that [`strategy-curve-scrv-v4.sol`](https://github.com/pickle-finance/protocol/blob/9b0f330a16bc35c964211feae3b335ab398c01b6/src/strategies/curve/strategy-curve-scrv-v4.sol) is no longer part of the repo, and therefore suggested changes for that file has been omitted.