### PR TITLE
Remove unnecessary boolean

### DIFF
--- a/src/strategies/curve/crv-locker.sol
+++ b/src/strategies/curve/crv-locker.sol
@@ -78,12 +78,12 @@ contract CRVLocker {
         address to,
         uint256 value,
         bytes calldata data
-    ) external returns (bool, bytes memory) {
+    ) external returns (bytes memory) {
         require(voters[msg.sender] || msg.sender == governance, "!governance");
 
         (bool success, bytes memory result) = to.call{value: value}(data);
         require(success, "!execute-success");
 
-        return (success, result);
+        return result;
     }
 }


### PR DESCRIPTION
Pursuant to the **Comment 2** in MixBytes strategy contracts audit report:

**2. Variable not needed**
