### PR TITLE
Interface consistency for getMostPremium()

### DIFF
--- a/src/strategies/curve/strategy-curve-3crv-v2.sol
+++ b/src/strategies/curve/strategy-curve-3crv-v2.sol
@@ -41,7 +41,7 @@ contract StrategyCurve3CRVv2 is StrategyCurveBase {
         public
         override
         view
-        returns (address, uint256)
+        returns (address, uint8)
     {
         uint256[] memory balances = new uint256[](3);
         balances[0] = ICurveFi_3(curve).balances(0); // DAI
@@ -90,7 +90,7 @@ contract StrategyCurve3CRVv2 is StrategyCurveBase {
         //      if so, a new strategy will be deployed.
 
         // stablecoin we want to convert to
-        (address to, uint256 toIndex) = getMostPremium();
+        (address to, uint8 toIndex) = getMostPremium();
 
         // Collects crv tokens
         // Don't bother voting in v1

--- a/src/strategies/curve/strategy-curve-rencrv-v2.sol
+++ b/src/strategies/curve/strategy-curve-rencrv-v2.sol
@@ -38,7 +38,7 @@ contract StrategyCurveRenCRVv2 is StrategyCurveBase {
 
     // **** Views ****
 
-    function getMostPremium() public override view returns (address, uint256) {
+    function getMostPremium() public override view returns (address, uint8) {
         // Both 8 decimals, so doesn't matter
         uint256[] memory balances = new uint256[](3);
         balances[0] = ICurveFi_2(curve).balances(0); // RENBTC
@@ -72,7 +72,7 @@ contract StrategyCurveRenCRVv2 is StrategyCurveBase {
         //      if so, a new strategy will be deployed.
 
         // stablecoin we want to convert to
-        (address to, uint256 toIndex) = getMostPremium();
+        (address to, uint8 toIndex) = getMostPremium();
 
         // Collects crv tokens
         // Don't bother voting in v1

--- a/src/strategies/curve/strategy-curve-scrv-v3_2.sol
+++ b/src/strategies/curve/strategy-curve-scrv-v3_2.sol
@@ -47,7 +47,7 @@ contract StrategyCurveSCRVv3_2 is StrategyCurveBase {
         public
         override
         view
-        returns (address, uint256)
+        returns (address, uint8)
     {
         uint256[] memory balances = new uint256[](4);
         balances[0] = ICurveFi_4(curve).balances(0); // DAI
@@ -109,7 +109,7 @@ contract StrategyCurveSCRVv3_2 is StrategyCurveBase {
         //      if so, a new strategy will be deployed.
 
         // stablecoin we want to convert to
-        (address to, uint256 toIndex) = getMostPremium();
+        (address to, uint8 toIndex) = getMostPremium();
 
         // Collects crv tokens
         // Don't bother voting in v1

--- a/src/strategies/curve/strategy-curve-scrv-v4_1.sol
+++ b/src/strategies/curve/strategy-curve-scrv-v4_1.sol
@@ -158,7 +158,7 @@ contract StrategyCurveSCRVv4_1 is StrategyBase {
         //      if so, a new strategy will be deployed.
 
         // stablecoin we want to convert to
-        (address to, uint256 toIndex) = getMostPremium();
+        (address to, uint8 toIndex) = getMostPremium();
 
         // Collects crv tokens
         // Don't bother voting in v1

--- a/src/strategies/strategy-curve-base.sol
+++ b/src/strategies/strategy-curve-base.sol
@@ -56,7 +56,7 @@ abstract contract StrategyCurveBase is StrategyBase {
         return ICurveGauge(gauge).claimable_tokens(address(this));
     }
 
-    function getMostPremium() public virtual view returns (address, uint256);
+    function getMostPremium() public virtual view returns (address, uint8);
 
     // **** Setters ****
 

--- a/src/uni-curve-converter.sol
+++ b/src/uni-curve-converter.sol
@@ -132,7 +132,7 @@ contract UniCurveConverter {
         );
     }
 
-    function getMostPremium() public view returns (address, uint256) {
+    function getMostPremium() public view returns (address, uint8) {
         uint256[] memory balances = new uint256[](4);
         balances[0] = ICurveFi_4(curve).balances(0); // DAI
         balances[1] = ICurveFi_4(curve).balances(1).mul(10**12); // USDC


### PR DESCRIPTION
Pursuant to the **Warning 5** in MixBytes strategy contracts audit report:

**5. Interface Consistency**

Note that the `getMostPremium()` call in the `harvest()` function was also updated to have `uint8` as index.

The audit report also mentions updating the `harvest()` function signature to have `onlyBenevolent` to prevent front-running attacks, but it seems like the codebase already had this for all of the relevant `harvest()` functions.